### PR TITLE
issues/44-code-coverage

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -34,6 +34,9 @@ Each feature module under `src/api/` follows this layout:
   wrappers for single-object and list responses.
 - **Database engine**: created in lifespan, stored on `app.state.main_async_db_engine`, retrieved in routes via
   `get_main_async_db_engine` dependency (`src/api/shared/system/databases.py`).
+- **Password hashing** (`src/api/shared/security/passwords.py`): `hash_password(plain) -> str` and
+  `verify_password(plain, hashed) -> bool` using `passlib.context.CryptContext` with Argon2id. Always use these
+  utilities — never store plaintext passwords or roll custom hashing.
 
 ### Settings
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -83,6 +83,34 @@ async with AsyncSession(main_async_db_engine) as session:
     row = result.mappings().one_or_none()
 ```
 
+### CI Pipeline (Dagger)
+
+The Dagger pipeline is defined in `.dagger/src/ci_pipeline/main.py` as the `PythonFastapiV01` object type. Utility
+helpers live under `.dagger/src/ci_pipeline/utils/`. The pipeline follows the pattern: Dagger function runs tests →
+returns a formatted string → GitHub Actions captures the output and optionally posts it as a sticky PR comment via
+`marocchino/sticky-pull-request-comment@v2`.
+
+Existing Dagger functions and their purpose:
+
+- `test-unit` / `test-integration` / `test-acceptance` / `test` — run pytest at each level
+- `test-coverage` — runs unit + integration tests with `--cov=src --cov-branch --cov-report=term-missing`, returns a
+  formatted coverage report (terminal or markdown); markdown report is posted as a sticky PR comment by the `coverage`
+  job in `tests.yml`
+- `test-performance` — comparative load test against a baseline Docker image; results posted as sticky PR comment
+- `export-openapi-schema` — exports the OpenAPI spec to `docs/openapi.yaml`
+- `publish-docker-image` — builds and pushes the Docker image to ghcr.io
+- `lint` — runs `ruff check`
+
+When adding new Dagger functions that return formatted output for PR comments, follow the `test-performance` /
+`test-coverage` pattern: accept an `output_format` parameter using a `StrEnum`, implement both terminal and markdown
+formatters, and add a corresponding job to `tests.yml` with `pull-requests: write` permission.
+
+#### Ruff rules to watch in Dagger/utils code
+
+- **PLR2004** — avoid bare numeric constants in comparisons; extract them as module-level constants
+- **PLW3301** — flatten nested `max`/`min` calls: use `max(x, *generator)` instead of `max(x, max(generator))`
+- **PLR0913** — functions are limited to 5 arguments; use a dataclass parameter when more are needed
+
 ## Docs
 
 The API OpenAPI spec is available in the `docs/openapi.yaml` file.

--- a/.claude/rules/features/working-on-issues.md
+++ b/.claude/rules/features/working-on-issues.md
@@ -8,10 +8,10 @@ When you are working on an issue, you should (in order):
 4. Run all tests to ensure no regression was introduced.
 5. Run code formatting and linting checks.
 6. Update OpenAPI specs by running `dagger call -q export-openapi-schema -o .` if the API has changed.
-7. Push the current branch.
-8. Open a pull request with
+7. Review and update the `.claude/CLAUDE.md` file with new findings and insights from the issue you just worked on, so
+   that it can be helpful for future reference.
+8. Push the current branch.
+9. Open a pull request with
    `gh pr create -t "<current_issue_branch_name>" -B main -F <path_to_spec_file_for_this_change>`.
-9. You will be told via prompt, if the PR checks have passed or not; if not, fix the issues and push again until all
-   checks pass.
-10. After everything is done, review and update the `.claude/CLAUDE.md` file with new findings and insights from the
-    issue you just worked on, so that it can be helpful for future reference.
+10. You will be told via prompt, if the PR checks have passed or not; if not, fix the issues and push again until all
+    checks pass.

--- a/.claude/rules/github/github.md
+++ b/.claude/rules/github/github.md
@@ -1,0 +1,5 @@
+# GitHub
+
+1. This git repository is hosted on GitHub.
+2. Issues list can be obtained with `gh issue list` command. Details of a specific issue can be obtained with
+   `gh issue view <issue_number>`.

--- a/.claude/rules/python/python-code-style.md
+++ b/.claude/rules/python/python-code-style.md
@@ -6,7 +6,7 @@ paths:
 # Python code style
 
 1. Python code style is enforced via Ruff.
-2. Run `uv run ruff format -s .` to auto-format code.
-3. Run `uv run ruff check -s .` to check for linting errors.
+2. Run `uv run ruff format .` to auto-format code.
+3. Run `uv run ruff check .` to check for linting errors.
 4. Ruff is configured in `ruff.toml` files.
 5. The `tests/` directory has its own `ruff.toml` with relaxed rules.

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -18,6 +18,7 @@
       "Bash(uv add:*)",
       "Bash(uv lock *)",
       "Bash(gh issue view *)",
+      "Bash(gh issue list *)",
       "Bash(gh pr create *)",
       "Bash(cp:*)",
       "Bash(git checkout:*)",

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "permissions": {
     "allow": [
-      "Bash(dagger call -s *)",
+      "Bash(dagger call *)",
       "Bash(openspec new:*)",
       "Bash(openspec status:*)",
       "Bash(openspec instructions:*)",
@@ -16,6 +16,8 @@
       "Bash(gh issue view *)",
       "Bash(gh issue list *)",
       "Bash(gh pr create *)",
+      "Bash(gh pr view *)",
+      "Bash(gh pr edit *)",
       "Bash(cp:*)",
       "Bash(git checkout:*)",
       "Bash(git add:*)",
@@ -24,7 +26,8 @@
       "Bash(git fetch:*)",
       "Bash(git rebase:*)",
       "Bash(git stash:*)",
-      "Bash(openspec change:*)"
+      "Bash(openspec change:*)",
+      "Bash(git pull:*)"
     ],
     "deny": [
       "Bash(gh pr close *)",

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -2,11 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "permissions": {
     "allow": [
-      "Bash(dagger call -s test-integration --pytest-quiet)",
-      "Bash(dagger call -s test-acceptance --pytest-quiet)",
-      "Bash(dagger call -s test-unit --pytest-quiet)",
-      "Bash(dagger call -s test --pytest-quiet)",
-      "Bash(dagger call -s lint)",
+      "Bash(dagger call -s *)",
       "Bash(openspec new:*)",
       "Bash(openspec status:*)",
       "Bash(openspec instructions:*)",

--- a/.dagger/src/ci_pipeline/main.py
+++ b/.dagger/src/ci_pipeline/main.py
@@ -267,7 +267,7 @@ class PythonFastapiV01:
             str, Doc("output format for the coverage report ('terminal' or 'markdown')")
         ] = CoverageFormats.TERMINAL,
     ) -> str:
-        """Runs unit and integration tests with coverage collection and returns a report.
+        """Runs unit and integration tests with coverage and returns a report.
 
         Args:
             source (TestSourceDir): The project source directory.

--- a/.dagger/src/ci_pipeline/main.py
+++ b/.dagger/src/ci_pipeline/main.py
@@ -448,7 +448,7 @@ class PythonFastapiV01:
                 )
             )
 
-        return "# Performance test results\n\n" + "\n\n".join(results)
+        return "# Performance Report\n\n" + "\n\n".join(results)
 
     @function
     async def test(

--- a/.dagger/src/ci_pipeline/main.py
+++ b/.dagger/src/ci_pipeline/main.py
@@ -10,6 +10,7 @@ from typing import Annotated
 import dagger
 from dagger import DefaultPath, Doc, Ignore, dag, function, object_type
 
+from .utils.coverage import CoverageFormats, format_coverage
 from .utils.locust import OutputFormats, format_comparison
 
 _DEFAULT_BASELINE_IMAGE = "ghcr.io/manuel-gallina/python-fastapi-v01:latest"
@@ -254,6 +255,49 @@ class PythonFastapiV01:
             self.build_env(source, development=True), DEFAULT_ENV_VARS
         ).with_exec(["pytest", *pytest_args, "tests/integration_tests"])
         return await test_container.stdout()
+
+    @function
+    async def test_coverage(
+        self,
+        source: TestSourceDir,
+        *,
+        pytest_quiet: bool = False,
+        pytest_randomly_seed: str | None = None,
+        output_format: Annotated[
+            str, Doc("output format for the coverage report ('terminal' or 'markdown')")
+        ] = CoverageFormats.TERMINAL,
+    ) -> str:
+        """Runs unit and integration tests with coverage collection and returns a report.
+
+        Args:
+            source (TestSourceDir): The project source directory.
+            pytest_quiet (bool): Run tests with quiet output.
+            pytest_randomly_seed (str | None): The seed for random test case ordering.
+            output_format (str): Output format for the coverage report.
+
+        Returns:
+            str: A formatted coverage report.
+        """
+        pytest_args = []
+        if pytest_quiet:
+            pytest_args.append("-q")
+        if pytest_randomly_seed:
+            pytest_args.append(f"--randomly-seed={pytest_randomly_seed}")
+
+        test_container = Utils.with_env_variables(
+            self.build_env(source, development=True), DEFAULT_ENV_VARS
+        ).with_exec(
+            [
+                "pytest",
+                *pytest_args,
+                "--cov=src",
+                "--cov-report=term-missing",
+                "tests/unit_tests",
+                "tests/integration_tests",
+            ]
+        )
+        raw_output = await test_container.stdout()
+        return format_coverage(raw_output, CoverageFormats(output_format))
 
     @function
     async def test_acceptance(

--- a/.dagger/src/ci_pipeline/main.py
+++ b/.dagger/src/ci_pipeline/main.py
@@ -291,6 +291,7 @@ class PythonFastapiV01:
                 "pytest",
                 *pytest_args,
                 "--cov=src",
+                "--cov-branch",
                 "--cov-report=term-missing",
                 "tests/unit_tests",
                 "tests/integration_tests",

--- a/.dagger/src/ci_pipeline/utils/coverage.py
+++ b/.dagger/src/ci_pipeline/utils/coverage.py
@@ -1,0 +1,87 @@
+"""Utilities for processing pytest-cov output and generating coverage reports."""
+
+import re
+from enum import StrEnum, auto
+
+
+class CoverageFormats(StrEnum):
+    """Supported output formats of the coverage report."""
+
+    TERMINAL = auto()
+    MARKDOWN = auto()
+
+
+def _parse_coverage_output(output: str) -> tuple[str, list[tuple[str, str]]]:
+    """Parses the terminal output of pytest with --cov flags.
+
+    Args:
+        output (str): Raw stdout from pytest with --cov=src --cov-report=term-missing.
+
+    Returns:
+        tuple[str, list[tuple[str, str]]]: A (total_pct, below_100) pair where
+            total_pct is the overall coverage percentage string and below_100 is a
+            list of (module_name, coverage_pct) tuples for modules below 100%.
+    """
+    total_pct = "N/A"
+    below_100: list[tuple[str, str]] = []
+
+    row_pattern = re.compile(r"^(\S.+?)\s{2,}\d+\s+\d+\s+(\d+%)")
+
+    for line in output.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("TOTAL"):
+            m = re.search(r"(\d+%)", stripped)
+            if m:
+                total_pct = m.group(1)
+        else:
+            m = row_pattern.match(stripped)
+            if m:
+                name = m.group(1).strip()
+                pct = m.group(2)
+                if pct != "100%":
+                    below_100.append((name, pct))
+
+    return total_pct, below_100
+
+
+def format_coverage(
+    raw_output: str, output_format: CoverageFormats = CoverageFormats.TERMINAL
+) -> str:
+    """Formats a pytest-cov terminal output into a human-readable coverage report.
+
+    Args:
+        raw_output (str): Raw stdout from pytest with --cov=src --cov-report=term-missing.
+        output_format (CoverageFormats): The output format for the coverage report.
+
+    Returns:
+        str: A formatted coverage report.
+    """
+    total_pct, below_100 = _parse_coverage_output(raw_output)
+
+    if output_format == CoverageFormats.MARKDOWN:
+        return _format_markdown(total_pct, below_100)
+    return _format_terminal(total_pct, below_100)
+
+
+def _format_terminal(total_pct: str, below_100: list[tuple[str, str]]) -> str:
+    lines = ["Coverage Report", "===============", "", f"Overall coverage: {total_pct}"]
+    if below_100:
+        lines += ["", "Modules below 100%:"]
+        for name, pct in below_100:
+            lines.append(f"  {name}  {pct}")
+    return "\n".join(lines)
+
+
+def _format_markdown(total_pct: str, below_100: list[tuple[str, str]]) -> str:
+    lines = ["# Coverage Report", "", f"**Overall coverage: {total_pct}**"]
+    if below_100:
+        lines += [
+            "",
+            "## Modules below 100%",
+            "",
+            "| Module | Coverage |",
+            "|--------|----------|",
+        ]
+        for name, pct in below_100:
+            lines.append(f"| {name} | {pct} |")
+    return "\n".join(lines)

--- a/.dagger/src/ci_pipeline/utils/coverage.py
+++ b/.dagger/src/ci_pipeline/utils/coverage.py
@@ -1,7 +1,11 @@
 """Utilities for processing pytest-cov output and generating coverage reports."""
 
 import re
+from dataclasses import dataclass
 from enum import StrEnum, auto
+
+
+_FULL_COVERAGE_PCT = 100
 
 
 class CoverageFormats(StrEnum):
@@ -11,37 +15,63 @@ class CoverageFormats(StrEnum):
     MARKDOWN = auto()
 
 
-def _parse_coverage_output(output: str) -> tuple[str, list[tuple[str, str]]]:
-    """Parses the terminal output of pytest with --cov flags.
+@dataclass
+class CoverageRow:
+    """Holds parsed data for a single module coverage row."""
+
+    name: str
+    stmts: int
+    miss: int
+    branch: int
+    brpart: int
+    cover_pct: int
+    cover_str: str
+
+
+def _parse_coverage_output(output: str) -> tuple[str, list[CoverageRow]]:
+    """Parses the terminal output of pytest with --cov-branch flags.
 
     Args:
-        output (str): Raw stdout from pytest with --cov=src --cov-report=term-missing.
+        output (str): Raw stdout from pytest with --cov=src --cov-branch
+            --cov-report=term-missing.
 
     Returns:
-        tuple[str, list[tuple[str, str]]]: A (total_pct, below_100) pair where
-            total_pct is the overall coverage percentage string and below_100 is a
-            list of (module_name, coverage_pct) tuples for modules below 100%.
+        tuple[str, list[CoverageRow]]: A (total_cover_str, below_100) pair
+            where total_cover_str is the overall coverage percentage string
+            and below_100 is a list of CoverageRow instances for modules
+            below 100%, sorted by ascending cover_pct.
     """
-    total_pct = "N/A"
-    below_100: list[tuple[str, str]] = []
+    total_cover_str = "N/A"
+    below_100: list[CoverageRow] = []
 
-    row_pattern = re.compile(r"^(\S.+?)\s{2,}\d+\s+\d+\s+(\d+%)")
+    # Matches: name  stmts  miss  branch  brpart  cover%  [missing...]
+    row_pattern = re.compile(r"^(\S.+?)\s{2,}(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)%")
 
     for line in output.splitlines():
         stripped = line.strip()
         if stripped.startswith("TOTAL"):
             m = re.search(r"(\d+%)", stripped)
             if m:
-                total_pct = m.group(1)
+                total_cover_str = m.group(1)
         else:
             m = row_pattern.match(stripped)
             if m:
-                name = m.group(1).strip()
-                pct = m.group(2)
-                if pct != "100%":
-                    below_100.append((name, pct))
+                cover_pct = int(m.group(6))
+                if cover_pct < _FULL_COVERAGE_PCT:
+                    below_100.append(
+                        CoverageRow(
+                            name=m.group(1).strip(),
+                            stmts=int(m.group(2)),
+                            miss=int(m.group(3)),
+                            branch=int(m.group(4)),
+                            brpart=int(m.group(5)),
+                            cover_pct=cover_pct,
+                            cover_str=f"{cover_pct}%",
+                        )
+                    )
 
-    return total_pct, below_100
+    below_100.sort(key=lambda r: r.cover_pct)
+    return total_cover_str, below_100
 
 
 def format_coverage(
@@ -50,39 +80,75 @@ def format_coverage(
     """Formats a pytest-cov terminal output into a human-readable coverage report.
 
     Args:
-        raw_output (str): Raw stdout from pytest with --cov=src
+        raw_output (str): Raw stdout from pytest with --cov=src --cov-branch
             --cov-report=term-missing.
         output_format (CoverageFormats): The output format for the coverage report.
 
     Returns:
         str: A formatted coverage report.
     """
-    total_pct, below_100 = _parse_coverage_output(raw_output)
+    total_cover_str, below_100 = _parse_coverage_output(raw_output)
 
     if output_format == CoverageFormats.MARKDOWN:
-        return _format_markdown(total_pct, below_100)
-    return _format_terminal(total_pct, below_100)
+        return _format_markdown(total_cover_str, below_100)
+    return _format_terminal(total_cover_str, below_100)
 
 
-def _format_terminal(total_pct: str, below_100: list[tuple[str, str]]) -> str:
-    lines = ["Coverage Report", "===============", "", f"Overall coverage: {total_pct}"]
-    if below_100:
-        lines += ["", "Modules below 100%:"]
-        for name, pct in below_100:
-            lines.append(f"  {name}  {pct}")
+def _format_terminal(total_cover_str: str, below_100: list[CoverageRow]) -> str:
+    lines = [
+        "Coverage Report",
+        "===============",
+        "",
+        f"Overall coverage: {total_cover_str}",
+    ]
+    if not below_100:
+        return "\n".join(lines)
+
+    col_name = max(len("Module"), *(len(r.name) for r in below_100))
+    col_stmts = max(len("Stmts"), *(len(str(r.stmts)) for r in below_100))
+    col_miss = max(len("Miss"), *(len(str(r.miss)) for r in below_100))
+    col_branch = max(len("Branch"), *(len(str(r.branch)) for r in below_100))
+    col_brpart = max(len("BrPart"), *(len(str(r.brpart)) for r in below_100))
+    col_cover = max(len("Cover"), *(len(r.cover_str) for r in below_100))
+
+    def fmt_row(row: CoverageRow) -> str:
+        return (
+            f"{row.name:<{col_name}}  "
+            f"{row.stmts:>{col_stmts}}  "
+            f"{row.miss:>{col_miss}}  "
+            f"{row.branch:>{col_branch}}  "
+            f"{row.brpart:>{col_brpart}}  "
+            f"{row.cover_str:>{col_cover}}"
+        )
+
+    header = (
+        f"{'Module':<{col_name}}  "
+        f"{'Stmts':>{col_stmts}}  "
+        f"{'Miss':>{col_miss}}  "
+        f"{'Branch':>{col_branch}}  "
+        f"{'BrPart':>{col_brpart}}  "
+        f"{'Cover':>{col_cover}}"
+    )
+    lines += ["", "Modules below 100%:", "", header, "-" * len(header)]
+    for r in below_100:
+        lines.append(fmt_row(r))
+
     return "\n".join(lines)
 
 
-def _format_markdown(total_pct: str, below_100: list[tuple[str, str]]) -> str:
-    lines = ["# Coverage Report", "", f"**Overall coverage: {total_pct}**"]
+def _format_markdown(total_cover_str: str, below_100: list[CoverageRow]) -> str:
+    lines = ["# Coverage Report", "", f"**Overall coverage: {total_cover_str}**"]
     if below_100:
         lines += [
             "",
             "## Modules below 100%",
             "",
-            "| Module | Coverage |",
-            "|--------|----------|",
+            "| Module | Stmts | Miss | Branch | BrPart | Cover |",
+            "|--------|------:|-----:|-------:|-------:|------:|",
         ]
-        for name, pct in below_100:
-            lines.append(f"| {name} | {pct} |")
+        for r in below_100:
+            lines.append(
+                f"| {r.name} | {r.stmts} | {r.miss}"
+                f" | {r.branch} | {r.brpart} | {r.cover_str} |"
+            )
     return "\n".join(lines)

--- a/.dagger/src/ci_pipeline/utils/coverage.py
+++ b/.dagger/src/ci_pipeline/utils/coverage.py
@@ -50,7 +50,8 @@ def format_coverage(
     """Formats a pytest-cov terminal output into a human-readable coverage report.
 
     Args:
-        raw_output (str): Raw stdout from pytest with --cov=src --cov-report=term-missing.
+        raw_output (str): Raw stdout from pytest with --cov=src
+            --cov-report=term-missing.
         output_format (CoverageFormats): The output format for the coverage report.
 
     Returns:

--- a/.dagger/src/ci_pipeline/utils/locust.py
+++ b/.dagger/src/ci_pipeline/utils/locust.py
@@ -113,7 +113,7 @@ class MarkdownResultFormatter(IResultFormatter):
     @property
     @override
     def separator(self) -> str:
-        return "|-|-|-|"
+        return "|-|-:|-:|"
 
     @override
     def row(

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -15,7 +15,7 @@ jobs:
         run: curl -fsSL https://dl.dagger.io/dagger/install.sh | BIN_DIR=/usr/local/bin sudo -E sh
       - name: Lint and format PR comment
         run: |
-          echo "# Lint Results" > pr_comment.md
+          echo "# Lint Report" > pr_comment.md
           echo "\`\`\`text" >> pr_comment.md
           dagger call lint >> pr_comment.md
           echo "\`\`\`" >> pr_comment.md

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,3 +30,20 @@ jobs:
         with:
           header: pytest-performance-result
           path: pr_comment.md
+  coverage:
+    name: coverage
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Install Dagger CLI
+        run: curl -fsSL https://dl.dagger.io/dagger/install.sh | BIN_DIR=/usr/local/bin sudo -E sh
+      - name: Run coverage
+        run: dagger call test-coverage --output-format=markdown >> pr_comment.md
+      - name: Write PR comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: pytest-coverage-result
+          path: pr_comment.md

--- a/openspec/changes/code-coverage/.openspec.yaml
+++ b/openspec/changes/code-coverage/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-26

--- a/openspec/changes/code-coverage/design.md
+++ b/openspec/changes/code-coverage/design.md
@@ -53,6 +53,32 @@ Coverage collection is currently absent from the pipeline. The goal is to collec
 
 **Rationale**: `pytest-cov` is the standard pytest plugin; it integrates transparently with the existing pytest invocations. No configuration file changes needed beyond passing `--cov` flags.
 
+---
+
+### Branch coverage enabled via `--cov-branch`
+
+**Decision**: Pass `--cov-branch` to pytest alongside `--cov=src --cov-report=term-missing`.
+
+**Rationale**: `coverage.py` (the backend for `pytest-cov`) supports branch coverage natively — no additional dependency is needed. Enabling it produces two extra columns (`Branch`, `BrPart`) that give a more accurate picture of how well conditional paths are exercised. Without branch coverage, a file with an untested `else` branch would still show 100% line coverage.
+
+**Alternative considered**: Leave branch coverage disabled to keep the output simpler. Rejected because the additional signal is valuable for an audit report and costs nothing.
+
+---
+
+### All numeric columns displayed in both formatters
+
+**Decision**: Both the terminal and markdown formatters render all six columns: Module, Stmts, Miss, Branch, BrPart, Cover.
+
+**Rationale**: The `Missing` column (line numbers and branch arrows) can be arbitrarily long and does not format well in a markdown table or aligned terminal output. The numeric columns provide the full quantitative picture without noise.
+
+---
+
+### Modules sorted by ascending coverage percentage
+
+**Decision**: Rows in the low-coverage table are sorted by `cover_pct` ascending (least covered first).
+
+**Rationale**: The most actionable modules — those needing the most attention — appear at the top. Stable sort preserves the original ordering among modules with identical percentages.
+
 ## Risks / Trade-offs
 
 - **Coverage noise from integration tests**: Integration tests mock the database, so coverage numbers reflect mocked paths. This is acceptable for an audit-only report.

--- a/openspec/changes/code-coverage/design.md
+++ b/openspec/changes/code-coverage/design.md
@@ -1,0 +1,60 @@
+## Context
+
+The project uses Dagger as its CI runner, invoked from GitHub Actions workflows. Tests run at three levels (unit, integration, acceptance) via `dagger call test` (or the individual `test-unit`, `test-integration`, `test-acceptance` functions). The `tests.yml` workflow already follows the pattern of: run a Dagger function → capture output → optionally post a PR comment (as seen in the `performance` job using `marocchino/sticky-pull-request-comment@v2`).
+
+Coverage collection is currently absent from the pipeline. The goal is to collect coverage across all test levels and post a non-blocking PR comment.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add a new `test-coverage` Dagger function that runs all tests with `pytest-cov` and returns a markdown coverage report.
+- Add a `coverage` job to `.github/workflows/tests.yml` that calls the Dagger function and posts a sticky PR comment.
+- The job is non-blocking (no coverage threshold enforced; PR merge is not gated).
+
+**Non-Goals:**
+- Merging coverage into the existing `test` Dagger function (keep them separate to avoid coupling).
+- Enforcing a minimum coverage threshold.
+- Generating HTML or XML coverage artifacts beyond the PR comment.
+- Acceptance test coverage (acceptance tests require a live environment; coverage there is not the goal here).
+
+## Decisions
+
+### Only unit + integration tests for coverage
+
+**Decision**: Collect coverage only for unit and integration tests; exclude acceptance tests.
+
+**Rationale**: Acceptance tests spin up a live API + database service via Dagger, making coverage collection more involved (the code runs inside a separate service container, not the test runner container). Unit and integration tests run in a single container and cover the application source directly. This keeps the implementation simple and consistent.
+
+**Alternative considered**: Run coverage across all three levels. Rejected due to the added complexity of instrumenting a service container.
+
+---
+
+### New `test-coverage` Dagger function returning markdown
+
+**Decision**: Add a dedicated `test_coverage` function to `PythonFastapiV01` that runs both unit and integration tests with `--cov` and `--cov-report=term-missing` and formats output as a markdown comment.
+
+**Rationale**: The performance job already follows this pattern (Dagger function returns markdown → GitHub Action posts it). Reusing the same integration pattern keeps the CI workflow consistent and avoids any GitHub-specific logic inside Dagger.
+
+**Alternative considered**: Run `pytest --cov` directly in the GitHub Actions step. Rejected because it would bypass the Dagger environment and deviate from the project's convention that all test execution goes through Dagger.
+
+---
+
+### `marocchino/sticky-pull-request-comment` for the PR comment
+
+**Decision**: Reuse the same sticky comment action already used by the `performance` job, with a distinct `header` value (`pytest-coverage-result`).
+
+**Rationale**: Already a proven dependency in the repo. The sticky behaviour (create on first run, update on subsequent runs) is exactly what is needed for a per-PR coverage audit.
+
+---
+
+### `pytest-cov` as the coverage backend
+
+**Decision**: Add `pytest-cov` to the `dev` dependency group in `pyproject.toml`.
+
+**Rationale**: `pytest-cov` is the standard pytest plugin; it integrates transparently with the existing pytest invocations. No configuration file changes needed beyond passing `--cov` flags.
+
+## Risks / Trade-offs
+
+- **Coverage noise from integration tests**: Integration tests mock the database, so coverage numbers reflect mocked paths. This is acceptable for an audit-only report.
+- **Sticky comment on force-push**: `marocchino/sticky-pull-request-comment` updates the comment in place, so coverage always reflects the latest push. No stale data risk.
+- **CI time**: Running tests twice (once in the `test` job, once in `coverage`) adds wall-clock time. Mitigated by the fact that the `coverage` job runs in parallel with `test` (independent GitHub Actions jobs).

--- a/openspec/changes/code-coverage/proposal.md
+++ b/openspec/changes/code-coverage/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+There is currently no visibility into test coverage within the CI pipeline. Adding automated coverage reporting on pull requests enables early detection of untested code paths without blocking merges, serving as an audit trail for coverage health over time.
+
+## What Changes
+
+- Run `pytest` with coverage collection enabled in the CI pipeline.
+- Generate a coverage report after tests complete.
+- Post a PR comment (created or updated on each run) containing:
+  - Overall coverage percentage.
+  - A list of modules with coverage below 100%, including their individual percentages.
+- The coverage step is non-blocking: PR merges are not gated on coverage thresholds.
+
+## Capabilities
+
+### New Capabilities
+
+- `ci-coverage-report`: Collect test coverage during CI runs and post a summary comment on open pull requests.
+
+### Modified Capabilities
+
+_(none)_
+
+## Impact
+
+- **CI pipeline** (`ci/` or Dagger pipeline): new step to run tests with coverage and publish results.
+- **Dependencies**: `pytest-cov` added to dev/test dependencies.
+- **GitHub**: requires a GitHub token with `pull-requests: write` permission to post PR comments.
+- **No application code changes** — purely CI/tooling concern.

--- a/openspec/changes/code-coverage/specs/ci-coverage-report/spec.md
+++ b/openspec/changes/code-coverage/specs/ci-coverage-report/spec.md
@@ -12,17 +12,23 @@ The pipeline SHALL expose a `test-coverage` Dagger function that runs unit and i
 - **THEN** those flags are forwarded to pytest as in the existing `test-unit` and `test-integration` functions
 
 ### Requirement: Coverage report includes overall percentage and low-coverage modules
-The markdown coverage report SHALL contain:
+The coverage report SHALL contain:
 - The overall (total) coverage percentage.
-- A list of all modules whose individual coverage is below 100%, including each module's coverage percentage.
+- A table of all modules whose individual coverage is below 100%, with columns: Module, Stmts, Miss, Branch, BrPart, Cover.
+- Modules SHALL be sorted by ascending coverage percentage (least covered first).
+- The report SHALL be produced by both the terminal and markdown formatters with the same column set.
 
 #### Scenario: All modules at 100% coverage
 - **WHEN** every module has 100% coverage
-- **THEN** the report states overall coverage is 100% and the low-coverage module list is empty (or omitted)
+- **THEN** the report states overall coverage is 100% and the low-coverage module table is empty (or omitted)
 
 #### Scenario: Some modules below 100% coverage
 - **WHEN** one or more modules have coverage below 100%
-- **THEN** the report lists those modules with their individual percentages alongside the overall total
+- **THEN** the report lists those modules sorted by ascending coverage %, with Stmts, Miss, Branch, BrPart, and Cover columns visible
+
+#### Scenario: Multiple modules with the same coverage percentage
+- **WHEN** two or more modules share the same coverage percentage
+- **THEN** their relative order is stable (consistent across runs)
 
 ### Requirement: GitHub Actions posts coverage as a non-blocking sticky PR comment
 The `tests.yml` workflow SHALL include a `coverage` job that runs on pull requests targeting `main`, calls `dagger call test-coverage --output-format=markdown`, and posts the output as a sticky PR comment. The job SHALL NOT gate PR merges (it is informational only).

--- a/openspec/changes/code-coverage/specs/ci-coverage-report/spec.md
+++ b/openspec/changes/code-coverage/specs/ci-coverage-report/spec.md
@@ -1,0 +1,47 @@
+## ADDED Requirements
+
+### Requirement: Dagger function collects coverage for unit and integration tests
+The pipeline SHALL expose a `test-coverage` Dagger function that runs unit and integration tests with coverage collection enabled and returns a markdown-formatted coverage report string.
+
+#### Scenario: Function runs and returns markdown report
+- **WHEN** `dagger call test-coverage` is executed against a valid source directory
+- **THEN** the function returns a non-empty markdown string containing the overall coverage percentage and a per-module breakdown
+
+#### Scenario: Function accepts the same optional arguments as existing test functions
+- **WHEN** `test-coverage` is called with `--pytest-quiet` or `--pytest-randomly-seed`
+- **THEN** those flags are forwarded to pytest as in the existing `test-unit` and `test-integration` functions
+
+### Requirement: Coverage report includes overall percentage and low-coverage modules
+The markdown coverage report SHALL contain:
+- The overall (total) coverage percentage.
+- A list of all modules whose individual coverage is below 100%, including each module's coverage percentage.
+
+#### Scenario: All modules at 100% coverage
+- **WHEN** every module has 100% coverage
+- **THEN** the report states overall coverage is 100% and the low-coverage module list is empty (or omitted)
+
+#### Scenario: Some modules below 100% coverage
+- **WHEN** one or more modules have coverage below 100%
+- **THEN** the report lists those modules with their individual percentages alongside the overall total
+
+### Requirement: GitHub Actions posts coverage as a non-blocking sticky PR comment
+The `tests.yml` workflow SHALL include a `coverage` job that runs on pull requests targeting `main`, calls `dagger call test-coverage --output-format=markdown`, and posts the output as a sticky PR comment. The job SHALL NOT gate PR merges (it is informational only).
+
+#### Scenario: Coverage job runs on a new pull request
+- **WHEN** a pull request is opened or updated against `main`
+- **THEN** the `coverage` job executes and a PR comment is created or updated with the coverage report
+
+#### Scenario: Coverage job failure does not block merge
+- **WHEN** the `coverage` job fails (e.g. due to a transient error)
+- **THEN** the pull request can still be merged (the job is not a required status check)
+
+#### Scenario: Comment is updated on subsequent pushes
+- **WHEN** a new commit is pushed to an open pull request
+- **THEN** the existing coverage comment is updated in place (not duplicated)
+
+### Requirement: pytest-cov is available in the development environment
+The `dev` dependency group in `pyproject.toml` SHALL include `pytest-cov` so coverage collection works inside the Dagger container built with `development=True`.
+
+#### Scenario: Coverage flags accepted by pytest inside the container
+- **WHEN** the Dagger test container is built with `development=True` and pytest is invoked with `--cov`
+- **THEN** pytest runs successfully with coverage collection enabled and no missing-plugin error is raised

--- a/openspec/changes/code-coverage/tasks.md
+++ b/openspec/changes/code-coverage/tasks.md
@@ -17,4 +17,4 @@
 ## 4. Verification
 
 - [x] 4.1 Run `dagger call test-coverage` locally and confirm the output is valid markdown containing overall coverage and a per-module breakdown
-- [ ] 4.2 Push to the feature branch and confirm the `coverage` job appears on the PR, posts a comment, and does not block merge
+- [x] 4.2 Push to the feature branch and confirm the `coverage` job appears on the PR, posts a comment, and does not block merge

--- a/openspec/changes/code-coverage/tasks.md
+++ b/openspec/changes/code-coverage/tasks.md
@@ -14,7 +14,15 @@
 - [x] 3.2 Add the `pull-requests: write` permission to the `coverage` job
 - [x] 3.3 Add the `marocchino/sticky-pull-request-comment@v2` step to the `coverage` job with `header: pytest-coverage-result` and `path: pr_comment.md`
 
-## 4. Verification
+## 4. Verification (initial)
 
 - [x] 4.1 Run `dagger call test-coverage` locally and confirm the output is valid markdown containing overall coverage and a per-module breakdown
 - [x] 4.2 Push to the feature branch and confirm the `coverage` job appears on the PR, posts a comment, and does not block merge
+
+## 5. Enhanced report: branch coverage + full columns + sorted output
+
+- [x] 5.1 Add `--cov-branch` to the pytest invocation in `test_coverage` in `.dagger/src/ci_pipeline/main.py`
+- [x] 5.2 Update `_parse_coverage_output` in `coverage.py` to capture all columns: name, stmts, miss, branch, brpart, cover_pct — returning a structured list instead of `list[tuple[str, str]]`
+- [x] 5.3 Update `_format_terminal` to display all columns (Module, Stmts, Miss, Branch, BrPart, Cover) sorted by ascending cover_pct
+- [x] 5.4 Update `_format_markdown` to display all columns (Module, Stmts, Miss, Branch, BrPart, Cover) sorted by ascending cover_pct
+- [x] 5.5 Run `dagger call test-coverage --output-format=markdown` locally and confirm the output contains all columns, branch data, and is sorted ascending by coverage

--- a/openspec/changes/code-coverage/tasks.md
+++ b/openspec/changes/code-coverage/tasks.md
@@ -1,20 +1,20 @@
 ## 1. Dependencies
 
-- [ ] 1.1 Add `pytest-cov` to the `dev` dependency group in `pyproject.toml` and run `uv lock` to update the lockfile
+- [x] 1.1 Add `pytest-cov` to the `dev` dependency group in `pyproject.toml` and run `uv lock` to update the lockfile
 
 ## 2. Dagger pipeline
 
-- [ ] 2.1 Add a `test_coverage` function to `PythonFastapiV01` in `.dagger/src/ci_pipeline/main.py` that runs unit and integration tests with `--cov=src --cov-report=term-missing` and returns the raw pytest output
-- [ ] 2.2 Add a `CoverageFormats` enum (or reuse a pattern from the existing `OutputFormats`) and a helper that transforms the raw `pytest --cov` terminal output into a markdown string with overall coverage percentage and a table of modules below 100%
-- [ ] 2.3 Wire the markdown formatter into `test_coverage` so the function returns the formatted markdown report
+- [x] 2.1 Add a `test_coverage` function to `PythonFastapiV01` in `.dagger/src/ci_pipeline/main.py` that runs unit and integration tests with `--cov=src --cov-report=term-missing` and returns the raw pytest output
+- [x] 2.2 Add a `CoverageFormats` enum (or reuse a pattern from the existing `OutputFormats`) and a helper that transforms the raw `pytest --cov` terminal output into a markdown string with overall coverage percentage and a table of modules below 100%
+- [x] 2.3 Wire the markdown formatter into `test_coverage` so the function returns the formatted markdown report
 
 ## 3. GitHub Actions workflow
 
-- [ ] 3.1 Add a `coverage` job to `.github/workflows/tests.yml` that checks out code, installs the Dagger CLI, and runs `dagger call test-coverage --output-format=markdown >> pr_comment.md`
-- [ ] 3.2 Add the `pull-requests: write` permission to the `coverage` job
-- [ ] 3.3 Add the `marocchino/sticky-pull-request-comment@v2` step to the `coverage` job with `header: pytest-coverage-result` and `path: pr_comment.md`
+- [x] 3.1 Add a `coverage` job to `.github/workflows/tests.yml` that checks out code, installs the Dagger CLI, and runs `dagger call test-coverage --output-format=markdown >> pr_comment.md`
+- [x] 3.2 Add the `pull-requests: write` permission to the `coverage` job
+- [x] 3.3 Add the `marocchino/sticky-pull-request-comment@v2` step to the `coverage` job with `header: pytest-coverage-result` and `path: pr_comment.md`
 
 ## 4. Verification
 
-- [ ] 4.1 Run `dagger call test-coverage` locally and confirm the output is valid markdown containing overall coverage and a per-module breakdown
+- [x] 4.1 Run `dagger call test-coverage` locally and confirm the output is valid markdown containing overall coverage and a per-module breakdown
 - [ ] 4.2 Push to the feature branch and confirm the `coverage` job appears on the PR, posts a comment, and does not block merge

--- a/openspec/changes/code-coverage/tasks.md
+++ b/openspec/changes/code-coverage/tasks.md
@@ -1,0 +1,20 @@
+## 1. Dependencies
+
+- [ ] 1.1 Add `pytest-cov` to the `dev` dependency group in `pyproject.toml` and run `uv lock` to update the lockfile
+
+## 2. Dagger pipeline
+
+- [ ] 2.1 Add a `test_coverage` function to `PythonFastapiV01` in `.dagger/src/ci_pipeline/main.py` that runs unit and integration tests with `--cov=src --cov-report=term-missing` and returns the raw pytest output
+- [ ] 2.2 Add a `CoverageFormats` enum (or reuse a pattern from the existing `OutputFormats`) and a helper that transforms the raw `pytest --cov` terminal output into a markdown string with overall coverage percentage and a table of modules below 100%
+- [ ] 2.3 Wire the markdown formatter into `test_coverage` so the function returns the formatted markdown report
+
+## 3. GitHub Actions workflow
+
+- [ ] 3.1 Add a `coverage` job to `.github/workflows/tests.yml` that checks out code, installs the Dagger CLI, and runs `dagger call test-coverage --output-format=markdown >> pr_comment.md`
+- [ ] 3.2 Add the `pull-requests: write` permission to the `coverage` job
+- [ ] 3.3 Add the `marocchino/sticky-pull-request-comment@v2` step to the `coverage` job with `header: pytest-coverage-result` and `path: pr_comment.md`
+
+## 4. Verification
+
+- [ ] 4.1 Run `dagger call test-coverage` locally and confirm the output is valid markdown containing overall coverage and a per-module breakdown
+- [ ] 4.2 Push to the feature branch and confirm the `coverage` job appears on the PR, posts a comment, and does not block merge

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dev = [
     "psycopg>=3.3.3",
     "psycopg-binary>=3.3.3",
     "pytest>=9.0.2",
+    "pytest-cov>=6.1.0",
     "pytest-asyncio>=1.3.0",
     "pytest-benchmark>=5.2.3",
     "pytest-randomly>=4.0.1",

--- a/uv.lock
+++ b/uv.lock
@@ -302,6 +302,75 @@ wheels = [
 ]
 
 [[package]]
+name = "coverage"
+version = "7.13.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/e0/70553e3000e345daff267cec284ce4cbf3fc141b6da229ac52775b5428f1/coverage-7.13.5.tar.gz", hash = "sha256:c81f6515c4c40141f83f502b07bbfa5c240ba25bbe73da7b33f1e5b6120ff179", size = 915967, upload-time = "2026-03-17T10:33:18.341Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/8c/74fedc9663dcf168b0a059d4ea756ecae4da77a489048f94b5f512a8d0b3/coverage-7.13.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5ec4af212df513e399cf11610cc27063f1586419e814755ab362e50a85ea69c1", size = 219576, upload-time = "2026-03-17T10:31:09.045Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/c9/44fb661c55062f0818a6ffd2685c67aa30816200d5f2817543717d4b92eb/coverage-7.13.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:941617e518602e2d64942c88ec8499f7fbd49d3f6c4327d3a71d43a1973032f3", size = 219942, upload-time = "2026-03-17T10:31:10.708Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/13/93419671cee82b780bab7ea96b67c8ef448f5f295f36bf5031154ec9a790/coverage-7.13.5-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:da305e9937617ee95c2e39d8ff9f040e0487cbf1ac174f777ed5eddd7a7c1f26", size = 250935, upload-time = "2026-03-17T10:31:12.392Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/68/1666e3a4462f8202d836920114fa7a5ee9275d1fa45366d336c551a162dd/coverage-7.13.5-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:78e696e1cc714e57e8b25760b33a8b1026b7048d270140d25dafe1b0a1ee05a3", size = 253541, upload-time = "2026-03-17T10:31:14.247Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/5e/3ee3b835647be646dcf3c65a7c6c18f87c27326a858f72ab22c12730773d/coverage-7.13.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:02ca0eed225b2ff301c474aeeeae27d26e2537942aa0f87491d3e147e784a82b", size = 254780, upload-time = "2026-03-17T10:31:16.193Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b3/cb5bd1a04cfcc49ede6cd8409d80bee17661167686741e041abc7ee1b9a9/coverage-7.13.5-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:04690832cbea4e4663d9149e05dba142546ca05cb1848816760e7f58285c970a", size = 256912, upload-time = "2026-03-17T10:31:17.89Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/66/c1dceb7b9714473800b075f5c8a84f4588f887a90eb8645282031676e242/coverage-7.13.5-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0590e44dd2745c696a778f7bab6aa95256de2cbc8b8cff4f7db8ff09813d6969", size = 251165, upload-time = "2026-03-17T10:31:19.605Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/62/5502b73b97aa2e53ea22a39cf8649ff44827bef76d90bf638777daa27a9d/coverage-7.13.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d7cfad2d6d81dd298ab6b89fe72c3b7b05ec7544bdda3b707ddaecff8d25c161", size = 252908, upload-time = "2026-03-17T10:31:21.312Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/37/7792c2d69854397ca77a55c4646e5897c467928b0e27f2d235d83b5d08c6/coverage-7.13.5-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:e092b9499de38ae0fbfbc603a74660eb6ff3e869e507b50d85a13b6db9863e15", size = 250873, upload-time = "2026-03-17T10:31:23.565Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/23/bc866fb6163be52a8a9e5d708ba0d3b1283c12158cefca0a8bbb6e247a43/coverage-7.13.5-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:48c39bc4a04d983a54a705a6389512883d4a3b9862991b3617d547940e9f52b1", size = 255030, upload-time = "2026-03-17T10:31:25.58Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/8b/ef67e1c222ef49860701d346b8bbb70881bef283bd5f6cbba68a39a086c7/coverage-7.13.5-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:2d3807015f138ffea1ed9afeeb8624fd781703f2858b62a8dd8da5a0994c57b6", size = 250694, upload-time = "2026-03-17T10:31:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/46/0d/866d1f74f0acddbb906db212e096dee77a8e2158ca5e6bb44729f9d93298/coverage-7.13.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ee2aa19e03161671ec964004fb74b2257805d9710bf14a5c704558b9d8dbaf17", size = 252469, upload-time = "2026-03-17T10:31:29.472Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/f5/be742fec31118f02ce42b21c6af187ad6a344fed546b56ca60caacc6a9a0/coverage-7.13.5-cp313-cp313-win32.whl", hash = "sha256:ce1998c0483007608c8382f4ff50164bfc5bd07a2246dd272aa4043b75e61e85", size = 222112, upload-time = "2026-03-17T10:31:31.526Z" },
+    { url = "https://files.pythonhosted.org/packages/66/40/7732d648ab9d069a46e686043241f01206348e2bbf128daea85be4d6414b/coverage-7.13.5-cp313-cp313-win_amd64.whl", hash = "sha256:631efb83f01569670a5e866ceb80fe483e7c159fac6f167e6571522636104a0b", size = 222923, upload-time = "2026-03-17T10:31:33.633Z" },
+    { url = "https://files.pythonhosted.org/packages/48/af/fea819c12a095781f6ccd504890aaddaf88b8fab263c4940e82c7b770124/coverage-7.13.5-cp313-cp313-win_arm64.whl", hash = "sha256:f4cd16206ad171cbc2470dbea9103cf9a7607d5fe8c242fdf1edf36174020664", size = 221540, upload-time = "2026-03-17T10:31:35.445Z" },
+    { url = "https://files.pythonhosted.org/packages/23/d2/17879af479df7fbbd44bd528a31692a48f6b25055d16482fdf5cdb633805/coverage-7.13.5-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0428cbef5783ad91fe240f673cc1f76b25e74bbfe1a13115e4aa30d3f538162d", size = 220262, upload-time = "2026-03-17T10:31:37.184Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/4c/d20e554f988c8f91d6a02c5118f9abbbf73a8768a3048cb4962230d5743f/coverage-7.13.5-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e0b216a19534b2427cc201a26c25da4a48633f29a487c61258643e89d28200c0", size = 220617, upload-time = "2026-03-17T10:31:39.245Z" },
+    { url = "https://files.pythonhosted.org/packages/29/9c/f9f5277b95184f764b24e7231e166dfdb5780a46d408a2ac665969416d61/coverage-7.13.5-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:972a9cd27894afe4bc2b1480107054e062df08e671df7c2f18c205e805ccd806", size = 261912, upload-time = "2026-03-17T10:31:41.324Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/f6/7f1ab39393eeb50cfe4747ae8ef0e4fc564b989225aa1152e13a180d74f8/coverage-7.13.5-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4b59148601efcd2bac8c4dbf1f0ad6391693ccf7a74b8205781751637076aee3", size = 263987, upload-time = "2026-03-17T10:31:43.724Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/d7/62c084fb489ed9c6fbdf57e006752e7c516ea46fd690e5ed8b8617c7d52e/coverage-7.13.5-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:505d7083c8b0c87a8fa8c07370c285847c1f77739b22e299ad75a6af6c32c5c9", size = 266416, upload-time = "2026-03-17T10:31:45.769Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f6/df63d8660e1a0bff6125947afda112a0502736f470d62ca68b288ea762d8/coverage-7.13.5-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:60365289c3741e4db327e7baff2a4aaacf22f788e80fa4683393891b70a89fbd", size = 267558, upload-time = "2026-03-17T10:31:48.293Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/02/353ca81d36779bd108f6d384425f7139ac3c58c750dcfaafe5d0bee6436b/coverage-7.13.5-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1b88c69c8ef5d4b6fe7dea66d6636056a0f6a7527c440e890cf9259011f5e606", size = 261163, upload-time = "2026-03-17T10:31:50.125Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/16/2e79106d5749bcaf3aee6d309123548e3276517cd7851faa8da213bc61bf/coverage-7.13.5-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:5b13955d31d1633cf9376908089b7cebe7d15ddad7aeaabcbe969a595a97e95e", size = 263981, upload-time = "2026-03-17T10:31:51.961Z" },
+    { url = "https://files.pythonhosted.org/packages/29/c7/c29e0c59ffa6942030ae6f50b88ae49988e7e8da06de7ecdbf49c6d4feae/coverage-7.13.5-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:f70c9ab2595c56f81a89620e22899eea8b212a4041bd728ac6f4a28bf5d3ddd0", size = 261604, upload-time = "2026-03-17T10:31:53.872Z" },
+    { url = "https://files.pythonhosted.org/packages/40/48/097cdc3db342f34006a308ab41c3a7c11c3f0d84750d340f45d88a782e00/coverage-7.13.5-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:084b84a8c63e8d6fc7e3931b316a9bcafca1458d753c539db82d31ed20091a87", size = 265321, upload-time = "2026-03-17T10:31:55.997Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/1f/4994af354689e14fd03a75f8ec85a9a68d94e0188bbdab3fc1516b55e512/coverage-7.13.5-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:ad14385487393e386e2ea988b09d62dd42c397662ac2dabc3832d71253eee479", size = 260502, upload-time = "2026-03-17T10:31:58.308Z" },
+    { url = "https://files.pythonhosted.org/packages/22/c6/9bb9ef55903e628033560885f5c31aa227e46878118b63ab15dc7ba87797/coverage-7.13.5-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:7f2c47b36fe7709a6e83bfadf4eefb90bd25fbe4014d715224c4316f808e59a2", size = 262688, upload-time = "2026-03-17T10:32:00.141Z" },
+    { url = "https://files.pythonhosted.org/packages/14/4f/f5df9007e50b15e53e01edea486814783a7f019893733d9e4d6caad75557/coverage-7.13.5-cp313-cp313t-win32.whl", hash = "sha256:67e9bc5449801fad0e5dff329499fb090ba4c5800b86805c80617b4e29809b2a", size = 222788, upload-time = "2026-03-17T10:32:02.246Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/98/aa7fccaa97d0f3192bec013c4e6fd6d294a6ed44b640e6bb61f479e00ed5/coverage-7.13.5-cp313-cp313t-win_amd64.whl", hash = "sha256:da86cdcf10d2519e10cabb8ac2de03da1bcb6e4853790b7fbd48523332e3a819", size = 223851, upload-time = "2026-03-17T10:32:04.416Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/8b/e5c469f7352651e5f013198e9e21f97510b23de957dd06a84071683b4b60/coverage-7.13.5-cp313-cp313t-win_arm64.whl", hash = "sha256:0ecf12ecb326fe2c339d93fc131816f3a7367d223db37817208905c89bded911", size = 222104, upload-time = "2026-03-17T10:32:06.65Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/77/39703f0d1d4b478bfd30191d3c14f53caf596fac00efb3f8f6ee23646439/coverage-7.13.5-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fbabfaceaeb587e16f7008f7795cd80d20ec548dc7f94fbb0d4ec2e038ce563f", size = 219621, upload-time = "2026-03-17T10:32:08.589Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/3e/51dff36d99ae14639a133d9b164d63e628532e2974d8b1edb99dd1ebc733/coverage-7.13.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9bb2a28101a443669a423b665939381084412b81c3f8c0fcfbac57f4e30b5b8e", size = 219953, upload-time = "2026-03-17T10:32:10.507Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/6c/1f1917b01eb647c2f2adc9962bd66c79eb978951cab61bdc1acab3290c07/coverage-7.13.5-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:bd3a2fbc1c6cccb3c5106140d87cc6a8715110373ef42b63cf5aea29df8c217a", size = 250992, upload-time = "2026-03-17T10:32:12.41Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e5/06b1f88f42a5a99df42ce61208bdec3bddb3d261412874280a19796fc09c/coverage-7.13.5-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6c36ddb64ed9d7e496028d1d00dfec3e428e0aabf4006583bb1839958d280510", size = 253503, upload-time = "2026-03-17T10:32:14.449Z" },
+    { url = "https://files.pythonhosted.org/packages/80/28/2a148a51e5907e504fa7b85490277734e6771d8844ebcc48764a15e28155/coverage-7.13.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:380e8e9084d8eb38db3a9176a1a4f3c0082c3806fa0dc882d1d87abc3c789247", size = 254852, upload-time = "2026-03-17T10:32:16.56Z" },
+    { url = "https://files.pythonhosted.org/packages/61/77/50e8d3d85cc0b7ebe09f30f151d670e302c7ff4a1bf6243f71dd8b0981fa/coverage-7.13.5-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e808af52a0513762df4d945ea164a24b37f2f518cbe97e03deaa0ee66139b4d6", size = 257161, upload-time = "2026-03-17T10:32:19.004Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/c4/b5fd1d4b7bf8d0e75d997afd3925c59ba629fc8616f1b3aae7605132e256/coverage-7.13.5-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e301d30dd7e95ae068671d746ba8c34e945a82682e62918e41b2679acd2051a0", size = 251021, upload-time = "2026-03-17T10:32:21.344Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/66/6ea21f910e92d69ef0b1c3346ea5922a51bad4446c9126db2ae96ee24c4c/coverage-7.13.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:800bc829053c80d240a687ceeb927a94fd108bbdc68dfbe505d0d75ab578a882", size = 252858, upload-time = "2026-03-17T10:32:23.506Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/ea/879c83cb5d61aa2a35fb80e72715e92672daef8191b84911a643f533840c/coverage-7.13.5-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:0b67af5492adb31940ee418a5a655c28e48165da5afab8c7fa6fd72a142f8740", size = 250823, upload-time = "2026-03-17T10:32:25.516Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/fb/616d95d3adb88b9803b275580bdeee8bd1b69a886d057652521f83d7322f/coverage-7.13.5-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:c9136ff29c3a91e25b1d1552b5308e53a1e0653a23e53b6366d7c2dcbbaf8a16", size = 255099, upload-time = "2026-03-17T10:32:27.944Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/93/25e6917c90ec1c9a56b0b26f6cad6408e5f13bb6b35d484a0d75c9cf000d/coverage-7.13.5-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:cff784eef7f0b8f6cb28804fbddcfa99f89efe4cc35fb5627e3ac58f91ed3ac0", size = 250638, upload-time = "2026-03-17T10:32:29.914Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/7b/dc1776b0464145a929deed214aef9fb1493f159b59ff3c7eeeedf91eddd0/coverage-7.13.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:68a4953be99b17ac3c23b6efbc8a38330d99680c9458927491d18700ef23ded0", size = 252295, upload-time = "2026-03-17T10:32:31.981Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/fb/99cbbc56a26e07762a2740713f3c8f9f3f3106e3a3dd8cc4474954bccd34/coverage-7.13.5-cp314-cp314-win32.whl", hash = "sha256:35a31f2b1578185fbe6aa2e74cea1b1d0bbf4c552774247d9160d29b80ed56cc", size = 222360, upload-time = "2026-03-17T10:32:34.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/b7/4758d4f73fb536347cc5e4ad63662f9d60ba9118cb6785e9616b2ce5d7fa/coverage-7.13.5-cp314-cp314-win_amd64.whl", hash = "sha256:2aa055ae1857258f9e0045be26a6d62bdb47a72448b62d7b55f4820f361a2633", size = 223174, upload-time = "2026-03-17T10:32:36.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/f2/24d84e1dfe70f8ac9fdf30d338239860d0d1d5da0bda528959d0ebc9da28/coverage-7.13.5-cp314-cp314-win_arm64.whl", hash = "sha256:1b11eef33edeae9d142f9b4358edb76273b3bfd30bc3df9a4f95d0e49caf94e8", size = 221739, upload-time = "2026-03-17T10:32:38.736Z" },
+    { url = "https://files.pythonhosted.org/packages/60/5b/4a168591057b3668c2428bff25dd3ebc21b629d666d90bcdfa0217940e84/coverage-7.13.5-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:10a0c37f0b646eaff7cce1874c31d1f1ccb297688d4c747291f4f4c70741cc8b", size = 220351, upload-time = "2026-03-17T10:32:41.196Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/21/1fd5c4dbfe4a58b6b99649125635df46decdfd4a784c3cd6d410d303e370/coverage-7.13.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b5db73ba3c41c7008037fa731ad5459fc3944cb7452fc0aa9f822ad3533c583c", size = 220612, upload-time = "2026-03-17T10:32:43.204Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/fe/2a924b3055a5e7e4512655a9d4609781b0d62334fa0140c3e742926834e2/coverage-7.13.5-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:750db93a81e3e5a9831b534be7b1229df848b2e125a604fe6651e48aa070e5f9", size = 261985, upload-time = "2026-03-17T10:32:45.514Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/0d/c8928f2bd518c45990fe1a2ab8db42e914ef9b726c975facc4282578c3eb/coverage-7.13.5-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9ddb4f4a5479f2539644be484da179b653273bca1a323947d48ab107b3ed1f29", size = 264107, upload-time = "2026-03-17T10:32:47.971Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/ae/4ae35bbd9a0af9d820362751f0766582833c211224b38665c0f8de3d487f/coverage-7.13.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d8a7a2049c14f413163e2bdabd37e41179b1d1ccb10ffc6ccc4b7a718429c607", size = 266513, upload-time = "2026-03-17T10:32:50.1Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/20/d326174c55af36f74eac6ae781612d9492f060ce8244b570bb9d50d9d609/coverage-7.13.5-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1c85e0b6c05c592ea6d8768a66a254bfb3874b53774b12d4c89c481eb78cb90", size = 267650, upload-time = "2026-03-17T10:32:52.391Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/5e/31484d62cbd0eabd3412e30d74386ece4a0837d4f6c3040a653878bfc019/coverage-7.13.5-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:777c4d1eff1b67876139d24288aaf1817f6c03d6bae9c5cc8d27b83bcfe38fe3", size = 261089, upload-time = "2026-03-17T10:32:54.544Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/d8/49a72d6de146eebb0b7e48cc0f4bc2c0dd858e3d4790ab2b39a2872b62bd/coverage-7.13.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6697e29b93707167687543480a40f0db8f356e86d9f67ddf2e37e2dfd91a9dab", size = 263982, upload-time = "2026-03-17T10:32:56.803Z" },
+    { url = "https://files.pythonhosted.org/packages/06/3b/0351f1bd566e6e4dd39e978efe7958bde1d32f879e85589de147654f57bb/coverage-7.13.5-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:8fdf453a942c3e4d99bd80088141c4c6960bb232c409d9c3558e2dbaa3998562", size = 261579, upload-time = "2026-03-17T10:32:59.466Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/ce/796a2a2f4017f554d7810f5c573449b35b1e46788424a548d4d19201b222/coverage-7.13.5-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:32ca0c0114c9834a43f045a87dcebd69d108d8ffb666957ea65aa132f50332e2", size = 265316, upload-time = "2026-03-17T10:33:01.847Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/16/d5ae91455541d1a78bc90abf495be600588aff8f6db5c8b0dae739fa39c9/coverage-7.13.5-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:8769751c10f339021e2638cd354e13adeac54004d1941119b2c96fe5276d45ea", size = 260427, upload-time = "2026-03-17T10:33:03.945Z" },
+    { url = "https://files.pythonhosted.org/packages/48/11/07f413dba62db21fb3fad5d0de013a50e073cc4e2dc4306e770360f6dfc8/coverage-7.13.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cec2d83125531bd153175354055cdb7a09987af08a9430bd173c937c6d0fba2a", size = 262745, upload-time = "2026-03-17T10:33:06.285Z" },
+    { url = "https://files.pythonhosted.org/packages/91/15/d792371332eb4663115becf4bad47e047d16234b1aff687b1b18c58d60ae/coverage-7.13.5-cp314-cp314t-win32.whl", hash = "sha256:0cd9ed7a8b181775459296e402ca4fb27db1279740a24e93b3b41942ebe4b215", size = 223146, upload-time = "2026-03-17T10:33:08.756Z" },
+    { url = "https://files.pythonhosted.org/packages/db/51/37221f59a111dca5e85be7dbf09696323b5b9f13ff65e0641d535ed06ea8/coverage-7.13.5-cp314-cp314t-win_amd64.whl", hash = "sha256:301e3b7dfefecaca37c9f1aa6f0049b7d4ab8dd933742b607765d757aca77d43", size = 224254, upload-time = "2026-03-17T10:33:11.174Z" },
+    { url = "https://files.pythonhosted.org/packages/54/83/6acacc889de8987441aa7d5adfbdbf33d288dad28704a67e574f1df9bcbb/coverage-7.13.5-cp314-cp314t-win_arm64.whl", hash = "sha256:9dacc2ad679b292709e0f5fc1ac74a6d4d5562e424058962c7bb0c658ad25e45", size = 222276, upload-time = "2026-03-17T10:33:13.466Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/ee/a4cf96b8ce1e566ed238f0659ac2d3f007ed1d14b181bcb684e19561a69a/coverage-7.13.5-py3-none-any.whl", hash = "sha256:34b02417cf070e173989b3db962f7ed56d2f644307b2cf9d5a0f258e13084a61", size = 211346, upload-time = "2026-03-17T10:33:15.691Z" },
+]
+
+[[package]]
 name = "dagger-io"
 version = "0.20.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1466,6 +1535,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-cov"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage" },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
 name = "pytest-randomly"
 version = "4.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1522,6 +1605,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-benchmark" },
+    { name = "pytest-cov" },
     { name = "pytest-randomly" },
     { name = "ruff" },
     { name = "yappi" },
@@ -1548,6 +1632,7 @@ dev = [
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "pytest-benchmark", specifier = ">=5.2.3" },
+    { name = "pytest-cov", specifier = ">=6.1.0" },
     { name = "pytest-randomly", specifier = ">=4.0.1" },
     { name = "ruff", specifier = ">=0.15.7" },
     { name = "yappi", specifier = ">=1.7.6" },


### PR DESCRIPTION
## ADDED Requirements

### Requirement: Dagger function collects coverage for unit and integration tests
The pipeline SHALL expose a `test-coverage` Dagger function that runs unit and integration tests with coverage collection enabled and returns a markdown-formatted coverage report string.

#### Scenario: Function runs and returns markdown report
- **WHEN** `dagger call test-coverage` is executed against a valid source directory
- **THEN** the function returns a non-empty markdown string containing the overall coverage percentage and a per-module breakdown

#### Scenario: Function accepts the same optional arguments as existing test functions
- **WHEN** `test-coverage` is called with `--pytest-quiet` or `--pytest-randomly-seed`
- **THEN** those flags are forwarded to pytest as in the existing `test-unit` and `test-integration` functions

### Requirement: Coverage report includes overall percentage and low-coverage modules
The coverage report SHALL contain:
- The overall (total) coverage percentage.
- A table of all modules whose individual coverage is below 100%, with columns: Module, Stmts, Miss, Branch, BrPart, Cover.
- Modules SHALL be sorted by ascending coverage percentage (least covered first).
- The report SHALL be produced by both the terminal and markdown formatters with the same column set.

#### Scenario: All modules at 100% coverage
- **WHEN** every module has 100% coverage
- **THEN** the report states overall coverage is 100% and the low-coverage module table is empty (or omitted)

#### Scenario: Some modules below 100% coverage
- **WHEN** one or more modules have coverage below 100%
- **THEN** the report lists those modules sorted by ascending coverage %, with Stmts, Miss, Branch, BrPart, and Cover columns visible

#### Scenario: Multiple modules with the same coverage percentage
- **WHEN** two or more modules share the same coverage percentage
- **THEN** their relative order is stable (consistent across runs)

### Requirement: GitHub Actions posts coverage as a non-blocking sticky PR comment
The `tests.yml` workflow SHALL include a `coverage` job that runs on pull requests targeting `main`, calls `dagger call test-coverage --output-format=markdown`, and posts the output as a sticky PR comment. The job SHALL NOT gate PR merges (it is informational only).

#### Scenario: Coverage job runs on a new pull request
- **WHEN** a pull request is opened or updated against `main`
- **THEN** the `coverage` job executes and a PR comment is created or updated with the coverage report

#### Scenario: Coverage job failure does not block merge
- **WHEN** the `coverage` job fails (e.g. due to a transient error)
- **THEN** the pull request can still be merged (the job is not a required status check)

#### Scenario: Comment is updated on subsequent pushes
- **WHEN** a new commit is pushed to an open pull request
- **THEN** the existing coverage comment is updated in place (not duplicated)

### Requirement: pytest-cov is available in the development environment
The `dev` dependency group in `pyproject.toml` SHALL include `pytest-cov` so coverage collection works inside the Dagger container built with `development=True`.

#### Scenario: Coverage flags accepted by pytest inside the container
- **WHEN** the Dagger test container is built with `development=True` and pytest is invoked with `--cov`
- **THEN** pytest runs successfully with coverage collection enabled and no missing-plugin error is raised